### PR TITLE
Issue #1955: Remove THREADS_PREFER_PTHREAD_FLAG

### DIFF
--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -56,7 +56,6 @@ macro(config_compiler_and_linker)
   unset(GTEST_HAS_PTHREAD)
   if (NOT gtest_disable_pthreads AND NOT MINGW)
     # Defines CMAKE_USE_PTHREADS_INIT and CMAKE_THREAD_LIBS_INIT.
-    set(THREADS_PREFER_PTHREAD_FLAG ON)
     find_package(Threads)
     if (CMAKE_USE_PTHREADS_INIT)
       set(GTEST_HAS_PTHREAD ON)


### PR DESCRIPTION
I think Googletest should not set `THREADS_PREFER_PTHREAD_FLAG` on its own. 

- If you link a CUDA-enabled language against a gtest on a machine where CMake detects -pthread, this will not compile because the flags is propagated to the CUDA target, but the flag is not recognized by nvcc. On this machine, we don't want the pthread flag. This is probably not that important as this is a general CMake problem and will be fixed with new CMake Versions (there are many issues, e.g. https://gitlab.kitware.com/cmake/cmake/merge_requests/2529 for MPI and many others).
- More importantly, if you do `find_package(Threads)` already before adding googletest, this will lead to strange behaviour: The first cmake pass will do the find_package(Threads) with the option disabled (or whatever the user specified), the second cmake pass will add the flag and find -pthread.

See also #1955 