### PR TITLE
Ticket3476 get googletest to build under epics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ x64-Release/
 # Ignore autoconf / automake files
 Makefile.in
 aclocal.m4
-configure
 build-aux/
 autom4te.cache/
 googletest/m4/libtool.m4
@@ -54,3 +53,25 @@ googlemock/CTestTestfile.cmake
 googlemock/Makefile
 googlemock/cmake_install.cmake
 googlemock/gtest
+
+# Ignore EPICS build files
+O.*/
+/db
+/bin
+/dbd
+/include
+/lib
+/templates
+envPaths
+cdCommands
+dllPath.bat
+runIOC.bat
+runIOC.sh
+relPaths.sh
+*.tag
+/data/
+/doc/
+*_info_positions.req
+*_info_settings.req
+/test-reports
+**/.vs

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,6 @@ googletest/xcode/.DS_Store
 # Ignore cmake generated directories and files.
 CMakeFiles
 CTestTestfile.cmake
-Makefile
 cmake_install.cmake
 googlemock/CMakeFiles
 googlemock/CTestTestfile.cmake

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+TOP = .
+include $(TOP)/configure/CONFIG
+# Directories to build, any order
+DIRS += configure
+DIRS += googletest
+
+# All dirs except configure depend on configure
+$(foreach dir, $(filter-out configure, $(DIRS)), \
+    $(eval $(dir)_DEPEND_DIRS += configure))
+	
+$(foreach dir, $(filter %Top, $(DIRS)), \
+    $(eval $(dir)_DEPEND_DIRS += $(filter %googletest, $(DIRS))))
+	
+include $(TOP)/configure/RULES_DIRS
+

--- a/configure/CONFIG
+++ b/configure/CONFIG
@@ -1,0 +1,29 @@
+# CONFIG - Load build configuration data
+#
+# Do not make changes to this file!
+
+# Allow user to override where the build rules come from
+RULES = $(EPICS_BASE)
+
+# RELEASE files point to other application tops
+include $(TOP)/configure/RELEASE
+-include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).Common
+ifdef T_A
+-include $(TOP)/configure/RELEASE.Common.$(T_A)
+-include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).$(T_A)
+endif
+
+CONFIG = $(RULES)/configure
+include $(CONFIG)/CONFIG
+
+# Override the Base definition:
+INSTALL_LOCATION = $(TOP)
+
+# CONFIG_SITE files contain other build configuration settings
+include $(TOP)/configure/CONFIG_SITE
+-include $(TOP)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+ifdef T_A
+ -include $(TOP)/configure/CONFIG_SITE.Common.$(T_A)
+ -include $(TOP)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
+endif
+

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -1,0 +1,43 @@
+# CONFIG_SITE
+
+# Make any application-specific changes to the EPICS build
+#   configuration variables in this file.
+#
+# Host/target specific settings can be specified in files named
+#   CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+#   CONFIG_SITE.Common.$(T_A)
+#   CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
+
+# CHECK_RELEASE controls the consistency checking of the support
+#   applications pointed to by the RELEASE* files.
+# Normally CHECK_RELEASE should be set to YES.
+# Set CHECK_RELEASE to NO to disable checking completely.
+# Set CHECK_RELEASE to WARN to perform consistency checking but
+#   continue building even if conflicts are found.
+CHECK_RELEASE = YES
+
+# Set this when you only want to compile this application
+#   for a subset of the cross-compiled target architectures
+#   that Base is built for.
+#CROSS_COMPILER_TARGET_ARCHS = vxWorks-ppc32
+
+# To install files into a location other than $(TOP) define
+#   INSTALL_LOCATION here.
+#INSTALL_LOCATION=</absolute/path/to/install/top>
+
+# Set this when the IOC and build host use different paths
+#   to the install location. This may be needed to boot from
+#   a Microsoft FTP server say, or on some NFS configurations.
+#IOCS_APPL_TOP = </IOC's/absolute/path/to/install/top>
+
+# For application debugging purposes, override the HOST_OPT and/
+#   or CROSS_OPT settings from base/configure/CONFIG_SITE
+#HOST_OPT = NO
+#CROSS_OPT = NO
+
+# These allow developers to override the CONFIG_SITE variable
+# settings without having to modify the configure/CONFIG_SITE
+# file itself.
+-include $(TOP)/../CONFIG_SITE.local
+-include $(TOP)/configure/CONFIG_SITE.local
+

--- a/configure/Makefile
+++ b/configure/Makefile
@@ -1,0 +1,8 @@
+TOP=..
+
+include $(TOP)/configure/CONFIG
+
+TARGETS = $(CONFIG_TARGETS)
+CONFIGS += $(subst ../,,$(wildcard $(CONFIG_INSTALLS)))
+
+include $(TOP)/configure/RULES

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -1,0 +1,10 @@
+# optional extra local definitions here
+
+# START OF AUTO GENERATED DEPENDENCIES
+GTEST=$(SUPPORT)/googletest/master/
+# END OF AUTO GENERATED DEPENDENCIES
+
+-include $(TOP)/configure/RELEASE.private
+
+include $(TOP)/../../../ISIS_CONFIG
+-include $(TOP)/../../../ISIS_CONFIG.$(EPICS_HOST_ARCH)

--- a/configure/RULES
+++ b/configure/RULES
@@ -1,0 +1,6 @@
+# RULES
+
+include $(CONFIG)/RULES
+
+# Library should be rebuilt because LIBOBJS may have changed.
+$(LIBNAME): ../Makefile

--- a/configure/RULES_DIRS
+++ b/configure/RULES_DIRS
@@ -1,0 +1,2 @@
+#RULES_DIRS
+include $(CONFIG)/RULES_DIRS

--- a/configure/RULES_TOP
+++ b/configure/RULES_TOP
@@ -1,0 +1,3 @@
+#RULES_TOP
+include $(CONFIG)/RULES_TOP
+

--- a/googletest/Makefile
+++ b/googletest/Makefile
@@ -1,0 +1,4 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+include $(TOP)/configure/RULES_DIRS

--- a/googletest/src/Makefile
+++ b/googletest/src/Makefile
@@ -1,0 +1,33 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+#----------------------------------------------------
+#  Optimization of db files using dbst (DEFAULT: NO)
+#DB_OPT = YES
+
+#----------------------------------------------------
+
+USR_CPPFLAGS += -I$(GTEST)/googletest/include -I$(GTEST)/googletest
+
+LIBRARY = gtest
+gtest_SRCS =  gtest-all.cc
+LIBTYPE:=SHARED
+
+#----------------------------------------------------
+# If <anyname>.db template is not named <anyname>*.template add
+# <anyname>_template = <templatename>
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+
+ifeq ($(STATIC_BUILD),NO)
+$(LIB_PREFIX)gtest$(LIB_SUFFIX) : $(LIB_PREFIX)%$(LIB_SUFFIX):
+	@$(RM)$@
+	$(ARCMD)
+ifneq ($(strip $(RANLIB)),)
+	$(RANLIB) $@
+endif
+endif


### PR DESCRIPTION
## Description of work done
- Added EPICS files to `.gitignore` and removed references to Makefiles.
- Added configure files and makefiles to allow us to make a `gtest.lib` to link against for running google tests.

## Acceptance Criteria
- [ ] Running `make` in top directory creates `gtest.lib` in the `lib` folder.